### PR TITLE
added Null-Space Damping & removed Pi/-Pi Jumps for unlimited rotation joints

### DIFF
--- a/config/TaskSpaceParams.cfg
+++ b/config/TaskSpaceParams.cfg
@@ -40,6 +40,15 @@ kd.add("d_roll", double_t, 0, "Damping Gain for Rotation about X",    20, 1,   6
 kd.add("d_pitch", double_t, 0, "Damping Gain for Rotation about Y",   20, 1,   60)
 kd.add("d_yaw", double_t, 0, "Damping Gain for Rotation about Z",     20, 1,   60)
 
+kqd = gen.add_group("Kqd") # Null-Space joint damping gain
+kqd.add("qd_0", double_t, 0, "Joint 0 Null-Space Joint Damping", 4, 2, 10)
+kqd.add("qd_1", double_t, 0, "Joint 1 Null-Space Joint Damping", 4, 2, 10)
+kqd.add("qd_2", double_t, 0, "Joint 2 Null-Space Joint Damping", 4, 2, 10)
+kqd.add("qd_3", double_t, 0, "Joint 3 Null-Space Joint Damping", 4, 2, 10)
+kqd.add("qd_4", double_t, 0, "Joint 4 Null-Space Joint Damping", 3, 1.5, 10)
+kqd.add("qd_5", double_t, 0, "Joint 5 Null-Space Joint Damping", 3, 1.5, 10)
+kqd.add("qd_6", double_t, 0, "Joint 6 Null-Space Joint Damping", 3, 1.5, 10)
+
 l = gen.add_group("L") # friction observer proportional gain
 l.add("l_0", double_t, 0, "Friction observer propotional gain for joint 0",    75, 20,   200)
 l.add("l_1", double_t, 0, "Friction observer propotional gain for joint 1",    75, 20,   200)

--- a/config/TaskSpaceParams.cfg
+++ b/config/TaskSpaceParams.cfg
@@ -41,13 +41,13 @@ kd.add("d_pitch", double_t, 0, "Damping Gain for Rotation about Y",   20, 1,   6
 kd.add("d_yaw", double_t, 0, "Damping Gain for Rotation about Z",     20, 1,   60)
 
 kqd = gen.add_group("Kqd") # Null-Space joint damping gain
-kqd.add("qd_0", double_t, 0, "Joint 0 Null-Space Joint Damping", 4, 2, 10)
-kqd.add("qd_1", double_t, 0, "Joint 1 Null-Space Joint Damping", 4, 2, 10)
-kqd.add("qd_2", double_t, 0, "Joint 2 Null-Space Joint Damping", 4, 2, 10)
-kqd.add("qd_3", double_t, 0, "Joint 3 Null-Space Joint Damping", 4, 2, 10)
-kqd.add("qd_4", double_t, 0, "Joint 4 Null-Space Joint Damping", 3, 1.5, 10)
-kqd.add("qd_5", double_t, 0, "Joint 5 Null-Space Joint Damping", 3, 1.5, 10)
-kqd.add("qd_6", double_t, 0, "Joint 6 Null-Space Joint Damping", 3, 1.5, 10)
+kqd.add("qd_0", double_t, 0, "Joint 0 Null-Space Joint Damping", 12, 2, 10)
+kqd.add("qd_1", double_t, 0, "Joint 1 Null-Space Joint Damping", 12, 2, 10)
+kqd.add("qd_2", double_t, 0, "Joint 2 Null-Space Joint Damping", 12, 2, 10)
+kqd.add("qd_3", double_t, 0, "Joint 3 Null-Space Joint Damping", 12, 2, 10)
+kqd.add("qd_4", double_t, 0, "Joint 4 Null-Space Joint Damping", 9, 1.5, 10)
+kqd.add("qd_5", double_t, 0, "Joint 5 Null-Space Joint Damping", 9, 1.5, 10)
+kqd.add("qd_6", double_t, 0, "Joint 6 Null-Space Joint Damping", 9, 1.5, 10)
 
 l = gen.add_group("L") # friction observer proportional gain
 l.add("l_0", double_t, 0, "Friction observer propotional gain for joint 0",    75, 20,   200)

--- a/include/gen3_compliant_controllers/TaskSpaceCompliantController.hpp
+++ b/include/gen3_compliant_controllers/TaskSpaceCompliantController.hpp
@@ -76,8 +76,9 @@ private:
   Eigen::MatrixXd mRotorInertiaMatrix;   // Rotor inertia matrix
   Eigen::MatrixXd mFrictionL;            // Friction observer matrix 1
   Eigen::MatrixXd mFrictionLp;           // Friction observer matrix 2
-  Eigen::MatrixXd mTaskKMatrix;          // Task compliance proportional gain matrix
-  Eigen::MatrixXd mTaskDMatrix;          // Task compliance derivative gain matrix
+  Eigen::MatrixXd mTaskKMatrix;          // Task compliance proportional gain matrix (virtual cartesian stiffness)
+  Eigen::MatrixXd mTaskDMatrix;          // Task compliance derivative gain matrix (virtual cartesian damping)
+  Eigen::MatrixXd mJointDMatrix;         // Task Null-Space joint damping matrix
 
   long long int mCount; // Used during initialization
 

--- a/src/JointSpaceCompliantController.cpp
+++ b/src/JointSpaceCompliantController.cpp
@@ -277,7 +277,11 @@ void JointSpaceCompliantController::update(const ros::Time& time, const ros::Dur
   Eigen::VectorXd mErrorTheta = mNominalThetaPrev - mDesiredTheta;
   Eigen::VectorXd add_pis = (mErrorTheta.array() > M_PI).select(Eigen::VectorXd::Constant(mNumControlledDofs, -2*M_PI), Eigen::VectorXd::Constant(mNumControlledDofs, 0)); // account for jump pi -> -pi
   add_pis += (mErrorTheta.array() <= -M_PI).select(Eigen::VectorXd::Constant(mNumControlledDofs, 2*M_PI), Eigen::VectorXd::Constant(mNumControlledDofs, 0)); // account for jump -pi -> pi
-  add_pis[1] = 0; add_pis[3] = 0; add_pis[5] = 0; // respect joint limits at pi/-pi for joints 2, 4, 6 (indices 1, 3, 5)
+  if (mNumControlledDofs == 6) {
+    add_pis[1] = 0; add_pis[2] = 0; add_pis[4] = 0; // respect joint limits at pi/-pi for joints 2, 3, 5 (indices 1, 2, 4)
+  } else {
+    add_pis[1] = 0; add_pis[3] = 0; add_pis[5] = 0; // respect joint limits at pi/-pi for joints 2, 4, 6 (indices 1, 3, 5)
+  }
   mTaskEffort = -mJointKMatrix * (mErrorTheta + add_pis)- mJointDMatrix * (mNominalThetaDotPrev - mDesiredThetaDot);
 
   double step_time;

--- a/src/JointSpaceCompliantController.cpp
+++ b/src/JointSpaceCompliantController.cpp
@@ -275,14 +275,21 @@ void JointSpaceCompliantController::update(const ros::Time& time, const ros::Dur
   mDesiredThetaDot = mDesiredVelocity;
 
   Eigen::VectorXd mErrorTheta = mNominalThetaPrev - mDesiredTheta;
-  Eigen::VectorXd add_pis = (mErrorTheta.array() > M_PI).select(Eigen::VectorXd::Constant(mNumControlledDofs, -2*M_PI), Eigen::VectorXd::Constant(mNumControlledDofs, 0)); // account for jump pi -> -pi
-  add_pis += (mErrorTheta.array() <= -M_PI).select(Eigen::VectorXd::Constant(mNumControlledDofs, 2*M_PI), Eigen::VectorXd::Constant(mNumControlledDofs, 0)); // account for jump -pi -> pi
-  if (mNumControlledDofs == 6) {
-    add_pis[1] = 0; add_pis[2] = 0; add_pis[4] = 0; // respect joint limits at pi/-pi for joints 2, 3, 5 (indices 1, 2, 4)
-  } else {
-    add_pis[1] = 0; add_pis[3] = 0; add_pis[5] = 0; // respect joint limits at pi/-pi for joints 2, 4, 6 (indices 1, 3, 5)
+  Eigen::VectorXd add_pis = (mErrorTheta.array() > M_PI).select(Eigen::VectorXd::Constant(mNumControlledDofs, -2 * M_PI), Eigen::VectorXd::Constant(mNumControlledDofs, 0)); // account for jump pi -> -pi
+  add_pis += (mErrorTheta.array() <= -M_PI).select(Eigen::VectorXd::Constant(mNumControlledDofs, 2 * M_PI), Eigen::VectorXd::Constant(mNumControlledDofs, 0)); // account for jump -pi -> pi
+  if (mNumControlledDofs == 6)
+  {
+    add_pis[1] = 0;
+    add_pis[2] = 0;
+    add_pis[4] = 0; // respect joint limits at pi/-pi for joints 2, 3, 5 (indices 1, 2, 4)
   }
-  mTaskEffort = -mJointKMatrix * (mErrorTheta + add_pis)- mJointDMatrix * (mNominalThetaDotPrev - mDesiredThetaDot);
+  else
+  {
+    add_pis[1] = 0;
+    add_pis[3] = 0;
+    add_pis[5] = 0; // respect joint limits at pi/-pi for joints 2, 4, 6 (indices 1, 3, 5)
+  }
+  mTaskEffort = -mJointKMatrix * (mErrorTheta + add_pis) - mJointDMatrix * (mNominalThetaDotPrev - mDesiredThetaDot);
 
   double step_time;
   step_time = 0.001;

--- a/src/JointSpaceCompliantController.cpp
+++ b/src/JointSpaceCompliantController.cpp
@@ -3,11 +3,11 @@
 #include <cmath>
 #include <functional>
 #include <stdexcept>
-#include <math.h>
 
 #include <gen3_compliant_controllers/JointSpaceCompliantController.hpp>
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/joint_state_interface.h>
+#include <math.h>
 #include <pluginlib/class_list_macros.h>
 
 #include "pinocchio/algorithm/joint-configuration.hpp"
@@ -275,7 +275,8 @@ void JointSpaceCompliantController::update(const ros::Time& time, const ros::Dur
   mDesiredThetaDot = mDesiredVelocity;
 
   Eigen::VectorXd mErrorTheta = mNominalThetaPrev - mDesiredTheta;
-  Eigen::VectorXd add_pis = (mErrorTheta.array() > M_PI).select(Eigen::VectorXd::Constant(mNumControlledDofs, -2 * M_PI), Eigen::VectorXd::Constant(mNumControlledDofs, 0)); // account for jump pi -> -pi
+  Eigen::VectorXd add_pis
+      = (mErrorTheta.array() > M_PI).select(Eigen::VectorXd::Constant(mNumControlledDofs, -2 * M_PI), Eigen::VectorXd::Constant(mNumControlledDofs, 0));       // account for jump pi -> -pi
   add_pis += (mErrorTheta.array() <= -M_PI).select(Eigen::VectorXd::Constant(mNumControlledDofs, 2 * M_PI), Eigen::VectorXd::Constant(mNumControlledDofs, 0)); // account for jump -pi -> pi
   if (mNumControlledDofs == 6)
   {

--- a/src/TaskSpaceCompliantController.cpp
+++ b/src/TaskSpaceCompliantController.cpp
@@ -150,7 +150,7 @@ bool TaskSpaceCompliantController::init(hardware_interface::RobotHW* robot, ros:
     mRotorInertiaMatrix.diagonal() << 0.3, 0.3, 0.3, 0.18, 0.18, 0.2;
     mFrictionL.diagonal() << 75, 75, 75, 40, 40, 40;
     mFrictionLp.diagonal() << 5, 5, 5, 4, 4, 4;
-    mJointDMatrix.diagonal() << 4, 4, 4, 3, 3, 3;
+    mJointDMatrix.diagonal() << 12, 12, 12, 9, 9, 9;
   }
   else
   {
@@ -158,7 +158,7 @@ bool TaskSpaceCompliantController::init(hardware_interface::RobotHW* robot, ros:
     mRotorInertiaMatrix.diagonal() << 0.3, 0.3, 0.3, 0.3, 0.18, 0.18, 0.2;
     mFrictionL.diagonal() << 75, 75, 75, 75, 40, 40, 40;
     mFrictionLp.diagonal() << 5, 5, 5, 5, 4, 4, 4;
-    mJointDMatrix.diagonal() << 4, 4, 4, 4, 3, 3, 3;
+    mJointDMatrix.diagonal() << 12, 12, 12, 12, 9, 9, 9;
   }
   mTaskKMatrix.diagonal() << 200, 200, 200, 100, 100, 100;
   mTaskDMatrix.diagonal() << 40, 40, 40, 20, 20, 20;

--- a/src/TaskSpaceCompliantController.cpp
+++ b/src/TaskSpaceCompliantController.cpp
@@ -369,7 +369,7 @@ void TaskSpaceCompliantController::update(const ros::Time& time, const ros::Dura
 
   mTaskEffort = dart_nominal_jacobian.transpose() * (-mTaskKMatrix * dart_error - mTaskDMatrix * (dart_nominal_jacobian * mNominalThetaDotPrev));
   Eigen::MatrixXd dart_nominal_jacobian_pseudo_inverse = dart_nominal_jacobian.completeOrthogonalDecomposition().pseudoInverse();
-  mTaskEffort = mTaskEffort - (Eigen::MatrixXd::Identity(mNumControlledDofs, mNumControlledDofs) - dart_nominal_jacobian_pseudo_inverse*dart_nominal_jacobian) * mJointDMatrix * mNominalThetaDotPrev;
+  mTaskEffort = mTaskEffort - (Eigen::MatrixXd::Identity(mNumControlledDofs, mNumControlledDofs) - dart_nominal_jacobian_pseudo_inverse * dart_nominal_jacobian) * mJointDMatrix * mNominalThetaDotPrev;
 
   double step_time;
   step_time = 0.001;

--- a/src/TaskSpaceCompliantController.cpp
+++ b/src/TaskSpaceCompliantController.cpp
@@ -199,6 +199,7 @@ void TaskSpaceCompliantController::dynamicReconfigureCallback(gen3_compliant_con
     mRotorInertiaMatrix.diagonal() << config.b_0, config.b_1, config.b_2, config.b_3, config.b_4, config.b_5;
     mFrictionL.diagonal() << config.l_0, config.l_1, config.l_2, config.l_3, config.l_4, config.l_5;
     mFrictionLp.diagonal() << config.lp_0, config.lp_1, config.lp_2, config.lp_3, config.lp_4, config.lp_5;
+    mJointDMatrix.diagonal() << config.qd_0, config.qd_1, config.qd_2, config.qd_3, config.qd_4, config.qd_5;
   }
   else
   {
@@ -206,6 +207,7 @@ void TaskSpaceCompliantController::dynamicReconfigureCallback(gen3_compliant_con
     mRotorInertiaMatrix.diagonal() << config.b_0, config.b_1, config.b_2, config.b_3, config.b_4, config.b_5, config.b_6;
     mFrictionL.diagonal() << config.l_0, config.l_1, config.l_2, config.l_3, config.l_4, config.l_5, config.l_6;
     mFrictionLp.diagonal() << config.lp_0, config.lp_1, config.lp_2, config.lp_3, config.lp_4, config.lp_5, config.lp_6;
+    mJointDMatrix.diagonal() << config.qd_0, config.qd_1, config.qd_2, config.qd_3, config.qd_4, config.qd_5, config.qd_6;
   }
   mTaskKMatrix.diagonal() << config.k_x, config.k_y, config.k_z, config.k_roll, config.k_pitch, config.k_yaw;
   mTaskDMatrix.diagonal() << config.d_x, config.d_y, config.d_z, config.d_roll, config.d_pitch, config.d_yaw;


### PR DESCRIPTION
- Added Null-Space damping to the Task Impedance Controller, which improves stability in most joint configurations (only relevant for the 7dof version). The damping parameters can be tuned via dynamic reconfigure. 
- Removed Pi/-Pi jumps for joints with unlimited rotation to Joint Impedance: Before, when you changed the desired joint position from +pi to -pi, the joint would rotate one full turn instead of not at all. Now, changes in the desired joint position will result in a motion according to the shortest path between the two joint positions, i.e., a change from +pi to -pi would not move the joint at all.